### PR TITLE
Fix build with the default config.

### DIFF
--- a/main/AppConfig.cpp.example
+++ b/main/AppConfig.cpp.example
@@ -3,20 +3,20 @@
 #include <hal/gpio_types.h>
 
 // TODO: Change this to the MAC address of the indoor module
-const std::array<const uint8_t, 6> AppConfig::MacAddress = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-const uint8_t AppConfig::BME280Address = 0x76;
+const std::array<const uint8_t, 6> AppConfig::macAddress = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+const uint8_t AppConfig::bme280Address = 0x76;
 // Serial1: GPIO23 - RX, GPIO18 - TX
-const int8_t AppConfig::Serial1RxPin = GPIO_NUM_23;
-const int8_t AppConfig::Serial1TxPin = GPIO_NUM_18;
+const int8_t AppConfig::serial1RxPin = GPIO_NUM_23;
+const int8_t AppConfig::serial1TxPin = GPIO_NUM_18;
 // Serial2: GPIO27 - RX, GPIO26 - TX
-const int8_t AppConfig::Serial2RxPin = GPIO_NUM_27;
-const int8_t AppConfig::Serial2TxPin = GPIO_NUM_26;
+const int8_t AppConfig::serial2RxPin = GPIO_NUM_27;
+const int8_t AppConfig::serial2TxPin = GPIO_NUM_26;
 // I2C: GPIO33 - SDA, GPIO32 - SCL
 const int8_t AppConfig::SDA = GPIO_NUM_33;
 const int8_t AppConfig::SCL = GPIO_NUM_32;
 // GPIO12 - step up enable
-const int8_t AppConfig::StepUpPin = GPIO_NUM_12;
+const int8_t AppConfig::stepUpPin = GPIO_NUM_12;
 // GPIO2 - input pin to read battery voltage
-const int8_t AppConfig::VoltagePin = GPIO_NUM_2;
+const int8_t AppConfig::voltagePin = GPIO_NUM_2;
 // Voltage divider ratio
-const float AppConfig::BatteryVoltageDivider = 0.6f;
+const float AppConfig::batteryVoltageDivider = 0.6f;


### PR DESCRIPTION
Adjust field names in the example.